### PR TITLE
fix error when open project on mac without Rider installed on it

### DIFF
--- a/Assets/Plugins/Editor/Rider/RiderPlugin.cs
+++ b/Assets/Plugins/Editor/Rider/RiderPlugin.cs
@@ -15,7 +15,7 @@ namespace Assets.Plugins.Editor.Rider
   {
     public static readonly string SlnFile;
     private static readonly string DefaultApp = EditorPrefs.GetString("kScriptsDefaultApp");
-    private static readonly FileInfo RiderFileInfo = new FileInfo(DefaultApp);
+    private static readonly FileInfo RiderFileInfo;
     public static bool IsDotNetFrameworkUsed {get { return RiderFileInfo.Extension == ".exe"; }}
 
     internal static bool Enabled
@@ -32,6 +32,8 @@ namespace Assets.Plugins.Editor.Rider
     {
       if (Enabled)
       {
+        RiderFileInfo = new FileInfo(DefaultApp);
+
         var newPath = RiderFileInfo.FullName;
         // try to search the new version
 


### PR DESCRIPTION
When open Unity project with embedded Rider Plugin on machine without installed Rider IDE on it we have an error:

System.ArgumentException: An empty file name is not valid.
  at System.IO.FileSystemInfo.CheckPath (System.String path) [0x0001c] in /Users/builduser/buildslave/mono/build/mcs/class/corlib/System.IO/FileSystemInfo.cs:255 
  at System.IO.FileInfo..ctor (System.String fileName) [0x00017] in /Users/builduser/buildslave/mono/build/mcs/class/corlib/System.IO/FileInfo.cs:58 
  at (wrapper remoting-invoke-with-check) System.IO.FileInfo:.ctor (string)
  at Assets.Plugins.Editor.Rider.RiderPlugin..cctor () [0x00000] in <filename unknown>:0 
UnityEditor.EditorAssemblies:SetLoadedEditorAssemblies(Assembly[])