### PR TITLE
Fix for non-standard Unity installation paths.

### DIFF
--- a/Assets/Plugins/Editor/Rider/RiderAssetPostprocessor.cs
+++ b/Assets/Plugins/Editor/Rider/RiderAssetPostprocessor.cs
@@ -76,9 +76,12 @@ namespace Assets.Plugins.Editor.JetBrains
 
     private static void SetXCodeDllReference(string name, XNamespace xmlns, XElement projectContentElement)
     {
-      var xcodeDllPath = Path.Combine("C:/Program Files/Unity/Editor/Data/PlaybackEngines/iOSSupport", name);
+      string unityAppBaseFolder = Path.GetDirectoryName(EditorApplication.applicationPath);
+
+      var xcodeDllPath = Path.Combine(unityAppBaseFolder, Path.Combine("Data/PlaybackEngines/iOSSupport", name));
       if (!File.Exists(xcodeDllPath))
-        xcodeDllPath = Path.Combine("/Applications/Unity/PlaybackEngines/iOSSupport", name);
+        xcodeDllPath = Path.Combine(unityAppBaseFolder, Path.Combine("PlaybackEngines/iOSSupport", name));
+
       if (File.Exists(xcodeDllPath))
       {
         var itemGroup = new XElement(xmlns + "ItemGroup");


### PR DESCRIPTION
Plugin would fail to set Xcode DLL references if Unity was installed in a non-standard location. This change causes plugin to retrieve Xcode DLL paths as relative to Unity editor executable location instead.

Tested only on OSX.