### PR TITLE
Fix an issue that Rider is still used, even after disabling it.

### DIFF
--- a/Assets/Plugins/Editor/Rider/RiderPlugin.cs
+++ b/Assets/Plugins/Editor/Rider/RiderPlugin.cs
@@ -14,7 +14,11 @@ namespace Assets.Plugins.Editor.JetBrains
   public static class RiderPlugin
   {
     private static readonly string SlnFile;
-    private static readonly string DefaultApp = EditorPrefs.GetString("kScriptsDefaultApp");
+    private static readonly string DefaultApp
+    {
+      get { return EditorPrefs.GetString("kScriptsDefaultApp"); }
+    }
+    
     public static readonly bool IsWindows;
 
     internal static bool Enabled


### PR DESCRIPTION
DefaultApp is now lazy evaluated, so querying whether RiderPlugin is enabled should give the correct result.
Previously, the property was evaluated only once (when statics are initialised, probably on AppDomain reload).

To reproduce the bug:
1. Set Rider as default script editor in Unity (under Preferences)
2. Import the files from this project.
3. Change back default script editor to MonoDevelop (or something else)

Try to open a script / click on a line from the Console window. Rider is still opened.