### PR TITLE
Fixed warning with Unity 5.6 beta

### DIFF
--- a/Assets/Plugins/Editor/JetBrains/RiderAssetPostprocessor.cs
+++ b/Assets/Plugins/Editor/JetBrains/RiderAssetPostprocessor.cs
@@ -219,7 +219,11 @@ namespace Plugins.Editor.JetBrains
         return "6";
 
       // Unity 5.5 supports C# 6, but only when targeting .NET 4.6. The enum doesn't exist pre Unity 5.5
+      #if UNITY_5_0 || UNITY_5_1 || UNITY_5_2 || UNITY_5_3|| UNITY_5_4 || UNITY_5_5
       if ((int)PlayerSettings.apiCompatibilityLevel >= 3)
+      #else
+      if ((int) PlayerSettings.GetApiCompatibilityLevel(EditorUserBuildSettings.selectedBuildTargetGroup) >= 3)
+      #endif
         return "6";
 
       return "4";


### PR DESCRIPTION
I noticed a warning with the new Unity 5.6 beta and fixed it. In Unity 5.6 you can set the application compatibility level per build-target so I chose to use the currently selected build target as indicator.