### PR TITLE
Create and delete EditorInstance.json

### DIFF
--- a/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
+++ b/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
@@ -78,9 +78,12 @@ namespace Plugins.Editor.JetBrains
       }
 
       var projectDirectory = Directory.GetParent(Application.dataPath).FullName;
+
       var projectName = Path.GetFileName(projectDirectory);
       SlnFile = Path.Combine(projectDirectory, string.Format("{0}.sln", projectName));
       UpdateUnitySettings(SlnFile);
+
+      InitializeEditorInstanceJson(projectDirectory);
 
       Initialized = true;
     }
@@ -99,6 +102,32 @@ namespace Plugins.Editor.JetBrains
       {
         Log("Exception on updating kScriptEditorArgs: " + e.Message);
       }
+    }
+
+    /// <summary>
+    /// Creates and deletes Library/EditorInstance.json containing version and process ID
+    /// </summary>
+    /// <param name="projectDirectory">Path to the project root directory</param>
+    private static void InitializeEditorInstanceJson(string projectDirectory)
+    {
+      // Only manage EditorInstance.json for 5.x - it's a native feature for 2017.x
+#if UNITY_5
+      Log("Writing Library/EditorInstance.json");
+
+      var library = Path.Combine(projectDirectory, "Library");
+      var editorInstanceJsonPath = Path.Combine(library, "EditorInstance.json");
+
+      File.WriteAllText(editorInstanceJsonPath, string.Format(@"{{
+  ""process_id"": {0},
+  ""version"": ""{1}""
+}}", Process.GetCurrentProcess().Id, Application.unityVersion));
+
+      AppDomain.CurrentDomain.DomainUnload += (sender, args) =>
+      {
+        Log("Deleting Library/EditorInstance.json");
+        File.Delete(editorInstanceJsonPath);
+      };
+#endif
     }
 
     /// <summary>
@@ -187,7 +216,7 @@ namespace Plugins.Editor.JetBrains
       var riderFileInfo = new FileInfo(riderPath);
       var macOSVersion = riderFileInfo.Extension == ".app";
       var riderExists = macOSVersion ? new DirectoryInfo(riderPath).Exists : riderFileInfo.Exists;
-      
+
       if (!riderExists)
       {
         EditorUtility.DisplayDialog("Rider executable not found", "Please update 'External Script Editor' path to JetBrains Rider.", "OK");


### PR DESCRIPTION
Automatically create and delete `Library/EditorInstance.json` when a project is loaded or closed. This file contains the Unity editor's process ID and editor version. Like:

```json
{
  "process_id": 7993,
  "version": "5.6.0f3"
}
```
